### PR TITLE
Implement link info endpoint

### DIFF
--- a/app/api/link_router.py
+++ b/app/api/link_router.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.db.models import Link, Click
+
+router = APIRouter(prefix="/api/links", tags=["links"])
+
+
+@router.get("/{code}/info")
+async def get_link_info(
+        code: str,
+        db: AsyncSession = Depends(get_db)
+):
+    result = await db.execute(
+        select(Link).where(Link.short_code == code)
+    )
+    link = result.scalar()
+
+    if not link:
+        raise HTTPException(status_code=404, detail="Link not found")
+
+    clicks = await db.execute(
+        select(func.count(Click.id)).where(Click.link_id == link.id)
+    )
+
+    return {
+        "original_url": link.original_url,
+        "short_code": link.short_code,
+        "clicks": clicks.scalar(),
+        "created_at": link.created_at.isoformat()
+    }

--- a/app/services/link_service.py
+++ b/app/services/link_service.py
@@ -4,9 +4,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 import redis.asyncio as redis
 from app.db.models import Link
+from app.db.session import get_db
 from app.services.validation import URLValidator
 from app.services.code_generator import CodeGenerator
 from app.core.config import settings
+from fastapi import Depends
 
 
 class LinkService:
@@ -22,7 +24,7 @@ class LinkService:
             self,
             original_url: str,
             custom_code: Optional[str] = None,
-            db: AsyncSession = None
+            db: AsyncSession = Depends(get_db)
     ) -> Link:
         """
         Creates a shortened link with caching.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ python-dotenv~=1.1.0
 alembic~=1.15.2
 aiosqlite~=0.21.0
 starlette~=0.46.1
+redis~=6.0.0b1
+shortuuid~=1.0.13
+pytest~=8.3.5
+setuptools~=78.1.0


### PR DESCRIPTION
### Related issue

Closes #12

### List of changes

- Add `GET /api/links/{code}` endpoint:
  - Returns:
    ```json
    {
      "original_url": "https://...",
      "short_code": "abc123",
      "clicks": 42,
      "created_at": "..."
    }
    ```
  - 404 for unknown codes