### PR TITLE
Implement link statistics endpoint

### DIFF
--- a/app/api/link_router.py
+++ b/app/api/link_router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select, func
+from sqlalchemy import select, func, extract
 from sqlalchemy.ext.asyncio import AsyncSession
-
+from datetime import datetime, timedelta
 from app.db.session import get_db
 from app.db.models import Link, Click
 
@@ -30,4 +30,68 @@ async def get_link_info(
         "short_code": link.short_code,
         "clicks": clicks.scalar(),
         "created_at": link.created_at.isoformat()
+    }
+
+
+@router.get("/{code}/stats")
+async def get_link_stats(
+        code: str,
+        db: AsyncSession = Depends(get_db),
+):
+    link = await db.execute(
+        select(Link).where(Link.short_code == code)
+    )
+    if not link.scalar():
+        raise HTTPException(status_code=404, detail="Link not found")
+    thirty_days_ago = datetime.now() - timedelta(days=30)
+
+    daily_stats = await db.execute(
+        select(
+            extract('day', Click.clicked_at).label("day"),
+            func.count().label("clicks")
+        )
+        .where(Click.link_id == link.id)
+        .where(Click.clicked_at >= thirty_days_ago)
+        .group_by("day")
+        .order_by("day")
+    )
+
+    geo_data = await db.execute(
+        select(
+            Click.country_code,
+            func.count().label("clicks")
+        )
+        .where(Click.link_id == link.id)
+        .where(Click.country_code.is_not(None))
+        .group_by(Click.country_code)
+        .order_by(func.count().desc())
+        .limit(10)
+    )
+
+    # Referrer data
+    referrer_data = await db.execute(
+        select(
+            Click.referrer,
+            func.count().label("visits")
+        )
+        .where(Click.link_id == link.id)
+        .where(Click.referrer.is_not(None))
+        .group_by(Click.referrer)
+        .order_by(func.count().desc())
+        .limit(10)
+    )
+
+    return {
+        "time_series": [
+            {"day": day, "clicks": clicks}
+            for day, clicks in daily_stats.all()
+        ],
+        "geo_distribution": [
+            {"country": country, "clicks": clicks}
+            for country, clicks in geo_data.all()
+        ],
+        "top_referrers": [
+            {"referrer": ref, "visits": visits}
+            for ref, visits in referrer_data.all()
+        ]
     }

--- a/app/api/link_router.py
+++ b/app/api/link_router.py
@@ -53,8 +53,8 @@ async def get_link_stats(
         )
         .where(Click.link_id == link.id)
         .where(Click.clicked_at >= thirty_days_ago)
-        .group_by("date")
-        .order_by("date")
+        .group_by("day")
+        .order_by("day")
     )
 
     geo_data = await db.execute(

--- a/app/api/link_router.py
+++ b/app/api/link_router.py
@@ -42,7 +42,7 @@ async def get_link_stats(
         select(Link).where(Link.short_code == code)
     )
     link = result.scalar()
-    if not link.scalar():
+    if not link:
         raise HTTPException(status_code=404, detail="Link not found")
     thirty_days_ago = datetime.now() - timedelta(days=30)
 

--- a/app/api/link_router.py
+++ b/app/api/link_router.py
@@ -38,9 +38,10 @@ async def get_link_stats(
         code: str,
         db: AsyncSession = Depends(get_db),
 ):
-    link = await db.execute(
+    result = await db.execute(
         select(Link).where(Link.short_code == code)
     )
+    link = result.scalar()
     if not link.scalar():
         raise HTTPException(status_code=404, detail="Link not found")
     thirty_days_ago = datetime.now() - timedelta(days=30)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -9,6 +9,9 @@ class Settings(BaseSettings):
     REDIS_HOST: str = "localhost"
     REDIS_PORT: int = 6379
     REDIS_TTL: int = 86400
+    RATE_LIMITS = {
+        'stats_endpoint': '10/minute'
+    }
 
     
 class Config:

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -19,3 +19,5 @@ class Click(Base):
     clicked_at = Column(DateTime, default=datetime.utcnow)
     ip_address = Column(String(45))
     user_agent = Column(String(512))
+    country_code = Column(String(2))
+    referrer = Column(String(512))


### PR DESCRIPTION
### Related issue

Closes #13

### List of changes

- Implement `GET /api/links/{code}/stats`:
    - Time-series click data (**last 30 days**)
    - **GeoIP** breakdown (if available)
    - Referrer tracking